### PR TITLE
fix: stop spamming nadeo if map is beaten

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -2,7 +2,7 @@
 name = "Author Time Check"
 author = "TheJaZed"
 category = "Game"
-version = "0.4"
+version = "0.5"
 siteid = 769
 
 [script]

--- a/src/Main.as
+++ b/src/Main.as
@@ -111,8 +111,10 @@ void MainLoop() {
         if (currentMapUID == mapIDChecked) continue;
         authorTime = map.TMObjective_AuthorTime;
 
-        if (S_HideIfATBeaten && !force_notif && WRbeatAT())
+        if (S_HideIfATBeaten && !force_notif && WRbeatAT()) {
+            mapIDChecked = currentMapUID;
             continue;
+        }
 
         if (map.ScriptMetadata is null) { // don't think this is possible, but just to be sure
             NotifyInconclusive();


### PR DESCRIPTION
fixes #9

The problem is that if map is beaten, we don't mark current map ID as checked.